### PR TITLE
Create Dockerfile.sonarscanner:3.0.3-alpine

### DIFF
--- a/Dockerfile.sonarscanner:3.0.3-alpine
+++ b/Dockerfile.sonarscanner:3.0.3-alpine
@@ -1,0 +1,15 @@
+FROM openjdk:8-alpine
+
+LABEL maintainer="Manuel Weidmann <manuel.weidmann@7p-group.com>"
+
+RUN apk add --no-cache  curl grep sed unzip
+
+ADD https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip /sonar.zip
+RUN unzip /sonar.zip
+RUN rm /sonar.zip
+
+#   ensure Sonar uses the provided Java for musl instead of a borked glibc one
+RUN sed -i 's/use_embedded_jre=true/use_embedded_jre=false/g' /sonar-scanner-3.0.3.778-linux/bin/sonar-scanner
+
+ENV SONAR_HOME /sonar-scanner-3.0.3.778-linux
+ENV PATH $PATH:$SONAR_HOME/bin


### PR DESCRIPTION
An alpine-variant of the image for people into wanting to reduce disk footprint a tad - it's ~380MB vs the ~840MB of the default one.

Note:
  - uses the alpine provided java instead of the bundled one (muslc vs. glibc)
  - does not provide a `sonar.properties` since we run those scans on demand and pass on arguments as needed

Have at it if you're interested, open to suggestions!