### PR TITLE
Allow non-root user to execute sonar-scanner

### DIFF
--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -15,7 +15,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 WORKDIR /root
 
-RUN curl --insecure -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
+RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
 RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -22,6 +22,10 @@ RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner
 
 ENV SONAR_RUNNER_HOME=/root/sonar-scanner
 ENV PATH $PATH:/root/sonar-scanner/bin
+# Allow non-root user to execute sonar-scanner
+RUN chmod +x /root \
+    && chmod +x /root/sonar-scanner \
+    && chmod -R +x /root/sonar-scanner/bin
 
 COPY sonar-runner.properties ./sonar-scanner/conf/sonar-scanner.properties
 

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -19,7 +19,7 @@ RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Di
 	unzip sonarscanner.zip && \
 	rm sonarscanner.zip && \
 	mv sonar-scanner-3.2.0.1227-linux /usr/lib/sonar-scanner && \
-    ln -s /usr/lib/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
+	ln -s /usr/lib/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
 
 ENV SONAR_RUNNER_HOME=/usr/lib/sonar-scanner
 

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -18,12 +18,12 @@ WORKDIR /src
 RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
-RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner
+RUN mv sonar-scanner-3.2.0.1227-linux /usr/lib/sonar-scanner
+RUN ln -s /usr/lib/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
 
-ENV SONAR_RUNNER_HOME=/root/sonar-scanner
-ENV PATH $PATH:/root/sonar-scanner/bin
+ENV SONAR_RUNNER_HOME=/usr/lib/sonar-scanner
 
-COPY sonar-runner.properties ./sonar-scanner/conf/sonar-scanner.properties
+COPY sonar-runner.properties /usr/lib/sonar-scanner/sonar-scanner/conf/sonar-scanner.properties
 
 # Use bash if you want to run the environment from inside the shell, otherwise use the command that actually runs the underlying stuff
 #CMD /bin/bash

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -27,4 +27,4 @@ COPY sonar-runner.properties /usr/lib/sonar-scanner/conf/sonar-scanner.propertie
 
 # Use bash if you want to run the environment from inside the shell, otherwise use the command that actually runs the underlying stuff
 #CMD /bin/bash
-CMD sonar-scanner -Dsonar.projectBaseDir=./src
+CMD sonar-scanner -Dsonar.projectBaseDir=/src

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -22,10 +22,6 @@ RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner
 
 ENV SONAR_RUNNER_HOME=/root/sonar-scanner
 ENV PATH $PATH:/root/sonar-scanner/bin
-# Allow non-root user to execute sonar-scanner
-RUN chmod +x /root \
-    && chmod +x /root/sonar-scanner \
-    && chmod -R +x /root/sonar-scanner/bin
 
 COPY sonar-runner.properties ./sonar-scanner/conf/sonar-scanner.properties
 

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -23,7 +23,7 @@ RUN ln -s /usr/lib/sonar-scanner/bin/sonar-scanner /usr/local/bin/sonar-scanner
 
 ENV SONAR_RUNNER_HOME=/usr/lib/sonar-scanner
 
-COPY sonar-runner.properties /usr/lib/sonar-scanner/sonar-scanner/conf/sonar-scanner.properties
+COPY sonar-runner.properties /usr/lib/sonar-scanner/conf/sonar-scanner.properties
 
 # Use bash if you want to run the environment from inside the shell, otherwise use the command that actually runs the underlying stuff
 #CMD /bin/bash

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -13,7 +13,7 @@ RUN sudo apt-get install -y nodejs build-essential
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-WORKDIR /root
+WORKDIR /src
 
 RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
 RUN unzip sonarscanner.zip

--- a/sonar-runner.properties
+++ b/sonar-runner.properties
@@ -28,7 +28,7 @@ sonar.jdbc.url=jdbc:h2:tcp://sonarqube/sonar
 sonar.projectKey=MyProjectKey
 sonar.projectName=My Project Name
 sonar.projectVersion=1
-sonar.projectBaseDir=/root/src
+sonar.projectBaseDir=/src
 sonar.sources=./
 
 # Exclude node_modules for JS/TS-based scanning


### PR DESCRIPTION
There may be a better way, but this is working for a use in Jenkins pipelines.
To reproduce the issue, just run with -u option :
`$ docker run --rm -ti -u 1000:1000 -v $(pwd):/root/src newtmitch/sonar-scanner:3.2 sonar-scanner -Dsonar.projectBaseDir=./src/dev`
`/bin/sh: 0: Can't open /root/sonar-scanner/bin/sonar-scanner`