### PR TITLE
Change Bintray URL to Sonarsource URL

### DIFF
--- a/Dockerfile.sonarscanner-3.0.3-alpine
+++ b/Dockerfile.sonarscanner-3.0.3-alpine
@@ -10,7 +10,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 WORKDIR /root
 
-RUN curl --insecure -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
+RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
 RUN mv sonar-scanner-3.0.3.778-linux sonar-scanner

--- a/Dockerfile.sonarscanner-3.0.3-full
+++ b/Dockerfile.sonarscanner-3.0.3-full
@@ -15,7 +15,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 WORKDIR /root
 
-RUN curl --insecure -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
+RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.0.3.778-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
 RUN mv sonar-scanner-3.0.3.778-linux sonar-scanner

--- a/Dockerfile.sonarscanner-3.2.0-alpine
+++ b/Dockerfile.sonarscanner-3.2.0-alpine
@@ -10,7 +10,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 WORKDIR /root
 
-RUN curl --insecure -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
+RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
 RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner

--- a/Dockerfile.sonarscanner-3.2.0-full
+++ b/Dockerfile.sonarscanner-3.2.0-full
@@ -15,7 +15,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 WORKDIR /root
 
-RUN curl --insecure -o ./sonarscanner.zip -L https://sonarsource.bintray.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
+RUN curl --insecure -o ./sonarscanner.zip -L https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-3.2.0.1227-linux.zip
 RUN unzip sonarscanner.zip
 RUN rm sonarscanner.zip
 RUN mv sonar-scanner-3.2.0.1227-linux sonar-scanner


### PR DESCRIPTION
SonarSource team changed the download site from Bintray to their own site (sonarsource.com).

**Change in this pull request:**
- Change download URL from `https://sonarsource.bintray.com` to `https://binaries.sonarsource.com`

**Reference:**
- https://community.sonarsource.com/t/download-site-has-changed/3176