### PR TITLE
[Dockerfile.sonnarscanner-4] add python-setuptools

### DIFF
--- a/Dockerfile.sonarscanner-4.0.0-full
+++ b/Dockerfile.sonarscanner-4.0.0-full
@@ -3,7 +3,7 @@ FROM openjdk:8
 LABEL maintainer="Ryan Mitchell <mitch@ryansmitchell.com>"
 
 RUN apt-get update
-RUN apt-get install -y curl git tmux htop maven sudo
+RUN apt-get install -y curl git tmux htop maven sudo python-setuptools python3-setuptools
 
 # Install Node - allows for scanning of Typescript
 RUN curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -


### PR DESCRIPTION
Enables extraction of version string for python packages using : 

```
      --define sonar.projectVersion=`python setup.py --version`
```